### PR TITLE
Updated for rc3 candidate.

### DIFF
--- a/u/ubuntu-console.yml
+++ b/u/ubuntu-console.yml
@@ -1,5 +1,5 @@
 console:
-  image: rancher/ubuntuconsole:v0.3.0-rc2
+  image: rancher/ubuntuconsole:v0.3.0-rc3
   privileged: true
   links:
   - cloud-init


### PR DESCRIPTION
Pulling older version in Rc3 causes CA certs to fail.